### PR TITLE
Support channel replies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ requests==2.20.0
 requests-toolbelt==0.9.1
 six==1.10.0
 slackclient==1.0.2
-slacker==0.9.42
+slacker==0.14.0
 slacksocket==0.7
 tqdm==4.45.0
 twine==3.1.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     keywords=["slack", "bot", "chat", "simple"],  # arbitrary keywords
     classifiers=[],
     install_requires=[
-        "slacker==0.9.42",
+        "slacker==0.14.0",
         "slacksocket>=0.7,!=0.8,<=0.9",
         "pyyaml",
         "websocket-client==0.48", # required to define as our dependency has a dependency which broke backwards compatibility

--- a/simple_slack_bot/simple_slack_bot.py
+++ b/simple_slack_bot/simple_slack_bot.py
@@ -100,8 +100,11 @@ class SimpleSlackBot:
         """
 
         logger.info(f"received an event of type {request.type} and slack event {request._slack_event.event}")
-
-        if request.type in self._registrations:
+        
+        # we ignore subtypes to ensure thread messages don't go to the channel as well, as two events are created
+        # i'm totally confident this will have unexpected consequences but have not discovered any at the time of 
+        # writing this
+        if request.type in self._registrations and request.subtype == None:
             for callback in self._registrations[request.type]:
                 try:
                     callback(request)

--- a/simple_slack_bot/slack_request.py
+++ b/simple_slack_bot/slack_request.py
@@ -43,6 +43,20 @@ class SlackRequest(object):
         return channel
 
     @property
+    def thread_ts(self):
+        """Gets the thread_ts from the underlying SlackEvent.
+        Note: This can be an empty String. For example, this will be an empty String when a message was not sent in a thread.
+
+        :return: the thread_ts this SlackEvent originated from, if there is one
+        """
+
+        thread_ts = ""
+        if "thread_ts" in self._slack_event.event:
+            thread_ts = self._slack_event.event["thread_ts"]
+
+        return thread_ts
+
+    @property
     def message(self):
         """Gets the underlying message from the SlackEvent
         Note: This can be an empty String. For example, this will be an empty String for the 'message_changed' event.
@@ -53,12 +67,13 @@ class SlackRequest(object):
         if "text" in self._slack_event.event:
             return self._slack_event.event["text"]
 
-    def write(self, content, channel=None):
+    def write(self, content, channel=None, thread_ts=None):
         """
         Writes the content to the channel
 
         :param content: The text you wish to send
         :param channel: By default send to same channel request came from, if any
+        :param thread_ts:      The time stamp of the message, indicating that this is a thread
         """
 
         if channel is None and self.channel != "":
@@ -67,7 +82,7 @@ class SlackRequest(object):
             logger.warning("no channel provided by developer or respective slack event")
 
         try:
-            self._slacker.chat.post_message(channel, content)
+            self._slacker.chat.post_message(channel, content, thread_ts=thread_ts)
         except Exception as e:
             logger.warning(e)
 


### PR DESCRIPTION
Added support to reply to channels when subscribing to the message event. Had to upgrade the dependency on Slacker, as the version I had pinned did not support threads, which is probably why I didn't look into this in the first place.

As noted in the commit messages, this implementation is not great. Specifically the code that only propagates the event if there is not `subtype`. This was the first fix I thought of when realizing that a reply to a thread sends three slack events. For example:

```
{'type': 'message', 'subtype': 'message_replied', 'hidden': True, 'message': {'client_msg_id': '8f047d3b-bb77-429f-a75d-d2f0cdb25bd3', 'type': 'message', 'text': 'hey', 'user': 'U389XUHT2', 'ts': '1591449692.004800', 'team': 'T38AP97Q9', 'blocks': [{'type': 'rich_text', 'block_id': 'GJc5', 'elements': [{'type': 'rich_text_section', 'elements': [{'type': 'text', 'text': 'hey'}]}]}], 'thread_ts': '1591449692.004800', 'reply_count': 24, 'reply_users_count': 2, 'latest_reply': '1591454854.014600', 'reply_users': ['U389XUHT2', 'B0117UPS0UR']}, 'channel': 'C3FAX3UCV', 'event_ts': '1591454854.014700', 'ts': '1591454854.014700'},
{'client_msg_id': '08d82eb4-543b-495c-ae6e-0e104805840a', 'suppress_notification': False, 'type': 'message', 'text': 'THREAD', 'user': 'U389XUHT2', 'team': 'T38AP97Q9', 'blocks': [{'type': 'rich_text', 'block_id': 'I97hA', 'elements': [{'type': 'rich_text_section', 'elements': [{'type': 'text', 'text': 'THREAD'}]}]}], 'thread_ts': '1591449692.004800', 'source_team': 'T38AP97Q9', 'user_team': 'T38AP97Q9', 'channel': 'C3FAX3UCV', 'event_ts': '1591454854.014600', 'ts': '1591454854.014600'},
{'type': 'message', 'subtype': 'message_replied', 'hidden': True, 'message': {'client_msg_id': '8f047d3b-bb77-429f-a75d-d2f0cdb25bd3', 'type': 'message', 'text': 'hey', 'user': 'U389XUHT2', 'ts': '1591449692.004800', 'team': 'T38AP97Q9', 'blocks': [{'type': 'rich_text', 'block_id': 'GJc5', 'elements': [{'type': 'rich_text_section', 'elements': [{'type': 'text', 'text': 'hey'}]}]}], 'thread_ts': '1591449692.004800', 'reply_count': 25, 'reply_users_count': 2, 'latest_reply': '1591454856.014900', 'reply_users': ['U389XUHT2', 'B0117UPS0UR']}, 'channel': 'C3FAX3UCV', 'event_ts': '1591454856.015000', 'ts': '1591454856.015000'}
```

If the `subtype` check is not implemented and one replies to a threaded message, you end up with one thread reply and two channel replies. I'm also unsure why one gets two events that are almost identical referencing the channel itself.

I 100% believe this `subtype` check will have unintended consequences but I have not discovered any yet.

Since this is my first public pull request, I'll wait on merging until reviewed. Please comment/question/challenge anything I've written. No hard feelings here at all.

@coltenkrauter 

Closes #35 